### PR TITLE
Feat(ad-db): implement mark-as-sold endpoint with database

### DIFF
--- a/server/controllers/CarController.js
+++ b/server/controllers/CarController.js
@@ -35,6 +35,31 @@ class CarController {
       });
     });
   }
+
+  /**
+    * @method markAsSold
+    * @description Update status of Ad
+    * @static
+    * @param {object} req - The request object
+    * @param {object} res - The response object
+    * @returns {object} JSON response
+    * @memberof CarController
+    */
+  static markAsSold(req, res) {
+    const { id } = req.params;
+    const { status } = req.body;
+    const updated = new Date();
+    const values = [status, updated, id];
+    const query = 'UPDATE cars SET status = $1, updated = $2 WHERE id = $3 RETURNING *';
+    return pool.query(query, values, (err, data) => {
+      if (err) return ErrorHandler.databaseError(res);
+      const car = data.rows[0];
+      return res.status(200).send({
+        status: 'success',
+        data: car,
+      });
+    });
+  }
 }
 
 export default CarController;

--- a/server/routes/carRoute.js
+++ b/server/routes/carRoute.js
@@ -20,4 +20,10 @@ carRoute.post('/car',
   CarValidator.validatePostCar,
   CarController.postCar);
 
+carRoute.patch('/car/:id/status',
+  Auth.userAuth,
+  Validator.validateId,
+  CarValidator.validateCarStatus,
+  CarController.markAsSold);
+
 export default carRoute;

--- a/server/tests/carSpec.js
+++ b/server/tests/carSpec.js
@@ -254,3 +254,167 @@ describe('/POST CAR route', () => {
       });
   });
 });
+
+describe('/PATCH CAR route', () => {
+  it('should return an error if user is not authenticated', done => {
+    const update = {
+      status: 'sold',
+    };
+    chai
+      .request(app)
+      .patch('/api/v1/car/1/status')
+      .set('authorization', '')
+      .send(update)
+      .end((err, res) => {
+        expect(res).to.have.status(401);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('You are not logged in');
+        done(err);
+      });
+  });
+
+  it('should return an error if token cannot be authenticated', done => {
+    const update = {
+      status: 'sold',
+    };
+    chai
+      .request(app)
+      .patch('/api/v1/car/1/status')
+      .set('authorization', 'urgjrigriirkjwUHJFRFFJrgfr')
+      .send(update)
+      .end((err, res) => {
+        expect(res).to.have.status(401);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('Authentication failed');
+        done(err);
+      });
+  });
+
+  it('should return an error if id is not a number', done => {
+    const update = {
+      status: 'sold',
+    };
+    chai
+      .request(app)
+      .patch('/api/v1/car/t1/status')
+      .set('authorization', `Bearer ${userToken}`)
+      .send(update)
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('Invalid Id, Please input a number');
+        done(err);
+      });
+  });
+
+  it('should return an error if id is badly formatted', done => {
+    const update = {
+      status: 'sold',
+    };
+    chai
+      .request(app)
+      .patch('/api/v1/car/1.01/status')
+      .set('authorization', `Bearer ${userToken}`)
+      .send(update)
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('Invalid id format');
+        done(err);
+      });
+  });
+
+  it('should return an error if status field is empty', done => {
+    const update = {
+      status: '',
+    };
+    chai
+      .request(app)
+      .patch('/api/v1/car/1/status')
+      .set('authorization', `Bearer ${userToken}`)
+      .send(update)
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('status field cannot be empty');
+        done(err);
+      });
+  });
+
+  it('should return an error if status is not sold', done => {
+    const update = {
+      status: 'slide',
+    };
+    chai
+      .request(app)
+      .patch('/api/v1/car/1/status')
+      .set('authorization', `Bearer ${userToken}`)
+      .send(update)
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('status must be sold');
+        done(err);
+      });
+  });
+
+  it('should return an error if car record is not found', done => {
+    const update = {
+      status: 'sold',
+    };
+    chai
+      .request(app)
+      .patch('/api/v1/car/16/status')
+      .set('authorization', `Bearer ${userToken}`)
+      .send(update)
+      .end((err, res) => {
+        expect(res).to.have.status(404);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('Car record not found');
+        done(err);
+      });
+  });
+
+  it('should return an error if car is already marked as sold', done => {
+    const update = {
+      status: 'sold',
+    };
+    chai
+      .request(app)
+      .patch('/api/v1/car/2/status')
+      .set('authorization', `Bearer ${userToken}`)
+      .send(update)
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('Car has already been marked as sold');
+        done(err);
+      });
+  });
+
+  it('should mark the car as sold if all credentials are valid', done => {
+    const update = {
+      status: 'sold',
+    };
+    chai
+      .request(app)
+      .patch('/api/v1/car/1/status')
+      .set('authorization', `Bearer ${userToken}`)
+      .send(update)
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body).to.be.an('object');
+        expect(res.body.data).to.have.property('status')
+          .eql('sold');
+        done(err);
+      });
+  });
+});


### PR DESCRIPTION


#### What does this PR do?


This PR implements mark-as-sold endpoint with database


#### Description of Tasks

- Setup test suite for mark-as-sold endpoint
- Create a middleware function to validate status and check if the car record exists
- Create a function to implement mark-as-sold endpoint with database
- Setup route for mark-as-sold endpoint
- Test using postman
- Ensure all tests are passing



#### How should this be manually tested?

Make a PATCH request to the ```/api/v1/car/<:car-id>/status``` endpoint


#### Relevant pivotal tracker story

[166720352](https://www.pivotaltracker.com/story/show/166720352)



#### Screenshots
![Screenshot (77)](https://user-images.githubusercontent.com/43535158/59565362-8d0e1200-904a-11e9-99e0-3e87863e6081.png)

![Screenshot (78)](https://user-images.githubusercontent.com/43535158/59565368-9eefb500-904a-11e9-872d-a79ee83f2b2b.png)
