### PR TITLE
Feat(ad-db): implement delete-ad endpoint

### DIFF
--- a/server/controllers/CarController.js
+++ b/server/controllers/CarController.js
@@ -134,6 +134,27 @@ class CarController {
       });
     });
   }
+
+  /**
+  * @method deleteCarAd
+  * @description Delete a specific car ad
+  * @static
+  * @param {object} req - The request object
+  * @param {object} res - The response object
+  * @returns {object} JSON response
+  * @memberof CarController
+  */
+  static deleteCarAd(req, res) {
+    const { id } = req.params;
+    const query = 'DELETE FROM cars WHERE id = $1';
+    pool.query(query, [id], err => {
+      if (err) return ErrorHandler.databaseError(res);
+      return res.status(200).send({
+        status: 'success',
+        message: 'Car ad deleted successfully',
+      });
+    });
+  }
 }
 
 export default CarController;

--- a/server/middlewares/Validator.js
+++ b/server/middlewares/Validator.js
@@ -81,6 +81,22 @@ class Validator {
     }
     return next();
   }
+
+  /**
+  * @method checkAdmin
+  * @description Check if user is admin
+  * @static
+  * @param {object} req - The request object
+  * @param {object} res - The response object
+  * @param {object} next
+  * @returns {object} next
+  * @memberof Validator
+  */
+  static checkAdmin(req, res, next) {
+    const { isAdmin } = req.user;
+    if (isAdmin) return next();
+    return ErrorHandler.validationError(res, 401, 'require admin access');
+  }
 }
 
 export default Validator;

--- a/server/routes/carRoute.js
+++ b/server/routes/carRoute.js
@@ -44,4 +44,11 @@ carRoute.get('/car',
   Validator.validateQuery,
   CarController.getUnsoldCars);
 
+carRoute.delete('/car/:id',
+  Auth.userAuth,
+  Validator.checkAdmin,
+  Validator.validateId,
+  CarValidator.checkCar,
+  CarController.deleteCarAd);
+
 export default carRoute;


### PR DESCRIPTION

#### What does this PR do?

This PR implements delete-ad endpoint with database



#### Description of Tasks

- Setup test suite for delete-ad endpoint
- Create a middleware function to check if the user is an admin
- Create a function to implement delete-ad endpoint with database
- Setup route for delete-ad endpoint
- Test using postman
- Ensure all tests are passing



#### How should this be manually tested?

Make a DELETE request to ``` /api/v1/car/:<car-id>```

#### Background context
Require admin access

#### Relevant pivotal tracker story

[166721030](https://www.pivotaltracker.com/story/show/166721030)



#### Screenshots

![Screenshot (88)](https://user-images.githubusercontent.com/43535158/59569266-c06a9400-907e-11e9-8aa9-b703b0d4c0b2.png)

![Screenshot (87)](https://user-images.githubusercontent.com/43535158/59569271-d0827380-907e-11e9-90eb-6b74077f8ec9.png)
