### PR TITLE
Feat(ad-db): implement get-new-unsold-cars endpoint

### DIFF
--- a/server/middlewares/CarValidator.js
+++ b/server/middlewares/CarValidator.js
@@ -20,8 +20,8 @@ class CarValidator {
     const queryState = req.query.state;
     const { state } = req.body;
     if (queryState) {
-      if (queryState.toLowerCase() === 'used') return next();
-      return ErrorHandler.validationError(res, 400, 'state must be used');
+      if (queryState.toLowerCase() === 'used' || queryState.toLowerCase() === 'new') return next();
+      return ErrorHandler.validationError(res, 400, 'state can either be \'new\' or \'used\'');
     }
     let err;
     if (!state) err = 'car state field cannot be empty';

--- a/server/tests/carSpec.js
+++ b/server/tests/carSpec.js
@@ -900,12 +900,12 @@ describe('/GET CAR route', () => {
         expect(res).to.have.status(400);
         expect(res.body).to.be.an('object');
         expect(res.body).to.have.property('error')
-          .eql('state must be used');
+          .eql('state can either be \'new\' or \'used\'');
         done(err);
       });
   });
 
-  it('should retrieve all unsold cars of a specific state if details are valid', done => {
+  it('should retrieve all used unsold cars if details are valid', done => {
     chai
       .request(app)
       .get('/api/v1/car?status=available&state=used')
@@ -915,6 +915,20 @@ describe('/GET CAR route', () => {
         expect(res.body).to.be.an('object');
         expect(res.body.data[0]).to.have.property('state')
           .eql('used');
+        done(err);
+      });
+  });
+
+  it('should retrieve all new unsold cars if details are valid', done => {
+    chai
+      .request(app)
+      .get('/api/v1/car?status=available&state=new')
+      .set('authorization', `Bearer ${userToken}`)
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body).to.be.an('object');
+        expect(res.body.data[0]).to.have.property('state')
+          .eql('new');
         done(err);
       });
   });


### PR DESCRIPTION


#### What does this PR do?

 This PR implements get-new-unsold-cars endpoint with database

#### Description of Tasks

- Setup test suite for get-new-unsold-cars endpoint
- Re-create a middleware function to validate query state
- Test using postman
- Ensure all tests are passing

#### How should this be manually tested?

Make a GET request to ``` /api/v1/car?status=available&state=new```


#### Relevant pivotal tracker story

[166748475](https://www.pivotaltracker.com/story/show/166748475)



#### Screenshots

![Screenshot (98)](https://user-images.githubusercontent.com/43535158/59655205-7c1be880-9191-11e9-8e8d-c7767fa7f06f.png)

![Screenshot (97)](https://user-images.githubusercontent.com/43535158/59655230-8b029b00-9191-11e9-8bf2-3c495e718f20.png)
